### PR TITLE
If we don't join the strings, we get funky output with extra commas.

### DIFF
--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -83,6 +83,6 @@ module.exports = function(grunt) {
     // iteratre over them calling the finder method defined above.
     // write out the resulting string the destination.
     var outStr = grunt.file.expand({nonull: true}, this.file.srcRaw).map(finder, this);
-    grunt.file.write(this.file.dest, outStr);
+    grunt.file.write(this.file.dest, outStr.join(''));
   });
 };


### PR DESCRIPTION
Without joining the strings we will have extra commas:

(function() {
// ...
})();
,,(function() {
// ...
})();

Joining the strings we have no extra commas:

(function() {
// ...
})();
(function() {
// ...
})();
