### PR TITLE
Filename transforms

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,16 @@ module.exports = function(grunt) {
         }
       },
 
+      // Run to test the default simple require options with a filepath transform.
+      filepath_transform_options: {
+        files: {
+          'tmp/simple_require_filepath_transforms' : ['test/fixtures/simple_require_filepath_transforms.js']
+        },
+        options: {
+          filepathTransform: function(filepath){ return 'test/fixtures/' + filepath; }
+        }
+      },
+
       // Run to test the default simple require options.
       custom_separator_options: {
         files: {

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ The wrapper around your code. Defaults to a closure-style function so locally de
 won't leak into the gloabl scope. The text of your source JavaScript file is available as `text`
 within a template.
 
+### filepathTransform
+Type: `Function`
+
+Default: `function(filepath){ return filepath; }`
+
+Specifying a filepath transform allows you to omit said portion of the filepath from your require statements. For example: when using `filepathTransform: function(filepath){ return 'lib/js/' + filepath; }` in your task options, require("lib/js/file.js") can instead be written as require("file.js").
+
 ### includeSourceURL
 Type: Boolean`
 

--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
     var requireMatcher = /require\([\'||\"](.*)[\'||\"]\)/;
 
     var options = this.options({
+      filepathTransform: function(filepath){ return filepath; },
       template: "(function() {\n\n<%= src %>\n\n})();",
       separator: "\n\n",
       includeSourceURL: false
@@ -53,9 +54,10 @@ module.exports = function(grunt) {
           // if the section is a require statement
           // recursively call find again. Otherwise
           // push the code section onto the buffer.
+          // apply the filepathTransform for matched files.
           var match = requireMatcher.exec(section);
           if (match) {
-            finder(match[1] + '.js');
+            finder(options.filepathTransform(match[1]) + '.js');
           } else {
             out.push({filepath: filepath, src: section});
           }

--- a/test/expected/simple_require_filepath_transforms
+++ b/test/expected/simple_require_filepath_transforms
@@ -1,0 +1,12 @@
+(function() {
+
+var a = 5;
+
+})();
+
+(function() {
+
+var simple_requires_come_before_here;
+
+
+})();

--- a/test/fixtures/simple_require_filepath_transforms.js
+++ b/test/fixtures/simple_require_filepath_transforms.js
@@ -1,0 +1,2 @@
+require('simple_require');
+var simple_requires_come_before_here;

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -11,6 +11,14 @@ exports.neuterTests = {
 
     test.done();
   },
+  simple_require_filepath_transforms: function(test) {
+
+    var actual = grunt.file.read('tmp/simple_require_filepath_transforms');
+    var expected = grunt.file.read('test/expected/simple_require_filepath_transforms');
+    test.equal(actual, expected, 'files are combined in correct order');
+
+    test.done();
+  },
   custom_separator_options: function(test){
 
     var actual = grunt.file.read('tmp/custom_separator_options');


### PR DESCRIPTION
Specifying a filepath transform allows you to omit said portion of the filepath from your require statements. For example: when using `filepathTransform: function(filepath){ return 'lib/js/' + filepath; }` in your task options, require("lib/js/file.js") can instead be written as require("file.js").
