### PR TITLE
change match/split regex to only match require()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,7 +109,20 @@ module.exports = function(grunt) {
         options: {
           skipFiles: ['test/fixtures/contains_commonjs_require.js']
         }
+      },
+      do_not_replace_requires_in_statements: {
+        files: {
+          'tmp/do_not_replace_requires_in_statements': ['test/fixtures/do_not_replace_requires_in_statements.js']
+        }
+      },
+      
+      // test that single line commented out require statements are not loaded
+      comment_out_require: {
+        files: {
+          'tmp/comment_out_require': ['test/fixtures/comment_out_require.js']
+        }
       }
+      
     },
     jshint: {
       all: [

--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -20,9 +20,9 @@ module.exports = function(grunt) {
 
     // matches `require('some/path/file');` statements.
     // no need to include a .js as this will be appended for you.
-    var requireSplitter = /(require\([\'||\"].*[\'||\"]\));+\n*/;
-    var requireMatcher = /require\([\'||\"](.*)[\'||\"]\)/;
-
+    var requireSplitter = /^\s*(require\([\'||\"].*[\'||\"]\));+\n*/m;
+    var requireMatcher = /^require\([\'||\"](.*)[\'||\"]\)/m;
+    
     // add mustache style delimiters
     grunt.template.addDelimiters('neuter', '{%', '%}');
     

--- a/test/expected/comment_out_require
+++ b/test/expected/comment_out_require
@@ -1,0 +1,20 @@
+(function() {
+
+//require('test/fixtures/comment_out_require_1');
+
+
+})();
+
+(function() {
+
+var iamrequired = true;
+
+
+})();
+
+(function() {
+
+/* a single line commented require statement should be skipped */
+
+
+})();

--- a/test/expected/do_not_replace_requires_in_statements
+++ b/test/expected/do_not_replace_requires_in_statements
@@ -1,0 +1,7 @@
+(function() {
+
+if(!Handlebars && typeof require === 'function') {
+  Handlebars = require('handlebars');
+}
+
+})();

--- a/test/fixtures/comment_out_require.js
+++ b/test/fixtures/comment_out_require.js
@@ -1,0 +1,3 @@
+//require('test/fixtures/comment_out_require_1');
+require('test/fixtures/comment_out_require_2');
+/* a single line commented require statement should be skipped */

--- a/test/fixtures/comment_out_require_1.js
+++ b/test/fixtures/comment_out_require_1.js
@@ -1,0 +1,1 @@
+var ishouldnotbehere = true;

--- a/test/fixtures/comment_out_require_2.js
+++ b/test/fixtures/comment_out_require_2.js
@@ -1,0 +1,1 @@
+var iamrequired = true;

--- a/test/fixtures/do_not_replace_requires_in_statements.js
+++ b/test/fixtures/do_not_replace_requires_in_statements.js
@@ -1,0 +1,3 @@
+if(!Handlebars && typeof require === 'function') {
+  Handlebars = require('handlebars');
+}

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -75,6 +75,7 @@ exports.neuterTests = {
 
     test.done();
   },
+
   ignores_files_when_told: function(test){
 
     var actual = grunt.file.read('tmp/ignores_files_when_told');
@@ -82,5 +83,23 @@ exports.neuterTests = {
     test.equal(actual, expected, 'ignores files when told');
 
     test.done();
+  },
+  
+  do_not_replace_requires_in_statements: function(test){
+    
+    var actual = grunt.file.read('tmp/do_not_replace_requires_in_statements');
+    var expected = grunt.file.read('test/expected/do_not_replace_requires_in_statements');
+    test.equal(actual, expected, 'require() statements in javascript statements are ignored');
+
+    test.done();
+  },
+  comment_out_require: function(test){
+    
+    var actual = grunt.file.read('tmp/comment_out_require');
+    var expected = grunt.file.read('test/expected/comment_out_require');
+    test.equal(actual, expected, 'single line commented require() statements are ignored');
+
+    test.done();
   }
+  
 };


### PR DESCRIPTION
statments when the line starts with whitespace or require().
This allows require() statements to be temporarily remove
with single line comments and ignores require() statements
that are part of a normal javascript statement.

fixes #7

Not sure if this steps on the toes of any of the use cases for grunt-neuter... but it does match the regex of the neuter implementation found here: https://github.com/wycats/rake-pipeline-web-filters/blob/master/lib/rake-pipeline-web-filters/neuter_filter.rb#L30
