### PR TITLE
Change template to use special delimiters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ Neuter is based on the [Rake pipline web-filter of the same name](https://github
 ### template
 Type: `String`
 
-Default: `"(function){ <%= text %> })();"`
+Default: `"(function){ {%= src %} })();"`
 
 The wrapper around your code. Defaults to a closure-style function so locally delcared variables
-won't leak into the gloabl scope. The text of your source JavaScript file is available as `text`
+won't leak into the gloabl scope. The text of your source JavaScript file is available as `src`
 within a template.
 
 ### filepathTransform

--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -23,9 +23,12 @@ module.exports = function(grunt) {
     var requireSplitter = /(require\([\'||\"].*[\'||\"]\));+\n*/;
     var requireMatcher = /require\([\'||\"](.*)[\'||\"]\)/;
 
+    // add mustache style delimiters
+    grunt.template.addDelimiters('neuter', '{%', '%}');
+    
     var options = this.options({
       filepathTransform: function(filepath){ return filepath; },
-      template: "(function() {\n\n<%= src %>\n\n})();",
+      template: "(function() {\n\n{%= src %}\n\n})();",
       separator: "\n\n",
       includeSourceURL: false,
       skipFiles: []
@@ -88,7 +91,8 @@ module.exports = function(grunt) {
       grunt.file.expand({nonull: true}, file.src).map(finder, this);
       var outStr = out.map(function(section){
         var templateData = {
-          data: section
+          data: section,
+          delimiters:'neuter'
         };
 
         if (options.includeSourceURL) {


### PR DESCRIPTION
The attached code closes issue #8. It changes the template delimiters you'd use when defining a template in order to circumvent Grunt's default processing:

``` javascript
/* Gruntfile */
neuter: {
  options: {
    template:'function(){ {%= src %} }'
  },
  ...
}

/* Neuter.js task */
console.log(this.options.template);
// output: "function(){ {%= src %} }"

console.log(grunt.template.process(options.template, templateData));
// output: function(){ /*my code here*/ }
```
