### PR TITLE
Add glob support to require()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -121,6 +121,13 @@ module.exports = function(grunt) {
         files: {
           'tmp/comment_out_require': ['test/fixtures/comment_out_require.js']
         }
+      },
+
+      // test that a file can require a glob
+      glob_require: {
+        files: {
+          'tmp/glob_require': ['test/fixtures/glob_require.js']
+        }
       }
       
     },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   ],
   "author": "Trek Glowacki <trek.glowacki@gamil.com>",
   "license": "MIT",
+  "dependencies": {
+		"glob": "~3.2.1"
+  },
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-jshint": "~0.2.0",

--- a/test/expected/glob_require
+++ b/test/expected/glob_require
@@ -1,0 +1,13 @@
+(function() {
+
+var a = 'a, from within glob';
+
+
+})();
+
+(function() {
+
+var b = 'b, from within glob';
+
+
+})();

--- a/test/fixtures/glob_require.js
+++ b/test/fixtures/glob_require.js
@@ -1,0 +1,1 @@
+require("test/fixtures/require_glob/*");

--- a/test/fixtures/require_glob/a.js
+++ b/test/fixtures/require_glob/a.js
@@ -1,0 +1,1 @@
+var a = 'a, from within glob';

--- a/test/fixtures/require_glob/b.js
+++ b/test/fixtures/require_glob/b.js
@@ -1,0 +1,1 @@
+var b = 'b, from within glob';

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -100,6 +100,14 @@ exports.neuterTests = {
     test.equal(actual, expected, 'single line commented require() statements are ignored');
 
     test.done();
+  },
+
+  glob_require: function(test){
+    var actual = grunt.file.read('tmp/glob_require');
+    var expected = grunt.file.read('test/expected/glob_require');
+    test.equal(actual, expected, 'require("glob/*") requires all files in that directory');
+
+    test.done();
   }
   
 };


### PR DESCRIPTION
Uses the [node-glob](https://github.com/isaacs/node-glob) package to do glob finds. Supports the same kind of globs that Grunt does. Still appends `*.js` to the end of the glob, so `require("folder/*")` requires `folder/*.js`. Closes part of #12.
