### PR TITLE
Added source map support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,16 +68,6 @@ module.exports = function(grunt) {
         }
       },
 
-      // Run to test the inclusion of source urls.
-      custom_source_url_inclusion_option: {
-        files: {
-          'tmp/custom_source_url_inclusion_option' : ['test/fixtures/simple_require_statements.js']
-        },
-        options: {
-          includeSourceURL: true
-        }
-      },
-
       // Run to test that duplicate require statemtns only write a source file to the
       // destination once.
       duplicate_require_statements: {
@@ -142,6 +132,14 @@ module.exports = function(grunt) {
       optional_dotjs: {
         files: {
           'tmp/optional_dotjs': ['test/fixtures/optional_dotjs.js']
+        }
+      },
+      source_maps: {
+        files: {
+          'tmp/source_maps': ['test/fixtures/glob_require.js']
+        },
+        options: {
+          includeSourceMap: true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "author": "Trek Glowacki <trek.glowacki@gamil.com>",
   "license": "MIT",
   "dependencies": {
-		"glob": "~3.2.1"
+		"glob": "~3.2.1",
+		"source-map": "~0.1.22"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/test/expected/custom_source_url_inclusion_option
+++ b/test/expected/custom_source_url_inclusion_option
@@ -1,3 +1,0 @@
-eval("(function() {\n\nvar a = 5;\n\n})();//@ sourceURL=test/fixtures/simple_require.js")
-
-eval("(function() {\n\nvar simple_requires_come_before_here;\n\n\n})();//@ sourceURL=test/fixtures/simple_require_statements.js")

--- a/test/expected/source_maps
+++ b/test/expected/source_maps
@@ -1,0 +1,13 @@
+(function() {
+
+var a = 'a, from within glob';
+
+
+})();
+
+(function() {
+
+var b = 'b, from within glob';
+
+
+})();//@ sourceMappingURL=source_maps.map

--- a/test/expected/source_maps.map
+++ b/test/expected/source_maps.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "source_maps",
+  "sources": [
+    "test/fixtures/require_glob/a.js",
+    "test/fixtures/require_glob/b.js"
+  ],
+  "names": [],
+  "mappings": ";;;AACA;A;;;;;;ACAA;A"
+}

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -27,22 +27,6 @@ exports.neuterTests = {
 
     test.done();
   },
-  custom_source_url_inclusion_option: function(test){
-
-    var actual = grunt.file.read('tmp/custom_source_url_inclusion_option');
-    var expected = grunt.file.read('test/expected/custom_source_url_inclusion_option');
-    test.equal(actual, expected, '@ sourceURL can be included for debugging');
-
-    test.done();
-  },
-  requires_are_only_included_once: function(test){
-
-    var actual = grunt.file.read('tmp/custom_source_url_inclusion_option');
-    var expected = grunt.file.read('test/expected/custom_source_url_inclusion_option');
-    test.equal(actual, expected, '@ sourceURL can be included for debugging');
-
-    test.done();
-  },
   duplicate_require_statements: function(test){
 
     var actual = grunt.file.read('tmp/duplicate_require_statements');
@@ -84,9 +68,9 @@ exports.neuterTests = {
 
     test.done();
   },
-  
+
   do_not_replace_requires_in_statements: function(test){
-    
+
     var actual = grunt.file.read('tmp/do_not_replace_requires_in_statements');
     var expected = grunt.file.read('test/expected/do_not_replace_requires_in_statements');
     test.equal(actual, expected, 'require() statements in javascript statements are ignored');
@@ -94,7 +78,7 @@ exports.neuterTests = {
     test.done();
   },
   comment_out_require: function(test){
-    
+
     var actual = grunt.file.read('tmp/comment_out_require');
     var expected = grunt.file.read('test/expected/comment_out_require');
     test.equal(actual, expected, 'single line commented require() statements are ignored');
@@ -130,6 +114,17 @@ exports.neuterTests = {
     test.equal(actual, expected, 'the .js extension is optional');
 
     test.done();
+  },
+
+  source_maps: function(test) {
+    var actualJs = grunt.file.read('tmp/source_maps');
+    var actualMap = grunt.file.read('tmp/source_maps.map');
+    var expectedJs = grunt.file.read('test/expected/source_maps');
+    var expectedMap = grunt.file.read('test/expected/source_maps.map');
+
+    test.equal(actualJs, expectedJs, 'the js includes sourceMap output');
+    test.equal(actualMap, expectedMap, 'the map is generated');
+
+    test.done();
   }
-  
 };


### PR DESCRIPTION
So, not really happy with the state of source URL-based debugging (`eval`? blergh!), I spent a bit of time adding source map support.

This replaces the `includeSourceURL` option with `includeSourceMap`, which places a proper source map in the same directory as the file.

The code is ~~a bit~~ ugly, but it's smart enough to ignore the newlines added by a template when mapping original lines to output lines. It relies on Mozilla's source-map library, as well as a concat strategy based on [grunt-concat-sourcemap](https://github.com/kozy4324/grunt-concat-sourcemap), to handle both concatenation and source map generation.
