### PR TITLE
Added basePath option and support for relative paths

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,6 +58,34 @@ module.exports = function(grunt) {
         }
       },
 
+      // Run to test the basePath option.
+      simple_basepath_options: {
+        // NOTE: this uses the filepath transform fixture because it performs the same operation
+        files: {
+          'tmp/simple_basepath_options' : ['test/fixtures/simple_require_filepath_transforms.js']
+        },
+        options: {
+          basePath: 'test/fixtures/'
+        }
+      },
+
+      // Run to test relative require statements.
+      relative_require_statements: {
+        files: {
+          'tmp/relative_require_statements' : ['test/fixtures/relative_require_statements.js']
+        }
+      },
+
+      // Run to test relative require statements in conjunction with the basePath option
+      relative_requires_with_basepath: {
+        files: {
+          'tmp/relative_requires_with_basepath' : ['test/fixtures/relative_requires_with_basepath.js'],
+        },
+        options: {
+          basePath: 'test/fixtures/'
+        }
+      },
+
       // Run to test the default simple require options.
       custom_separator_options: {
         files: {

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ var myVariable = 'hello';
 ```
 
 `b.js`
-```
+```javascript
 var variableFromB = 'b';
 window.availableEverywhere = true;
 ```
 
 Resulting output would be
 
-```
+```javascript
 (function(){
   var variableFromB = 'b';
   window.availableEverywhere = true;
@@ -79,8 +79,50 @@ Resulting output would be
 })();
 ```
 
-## Example Gruntfile Use
+## Relative Paths
+Relative paths using a dot to indicate the file's current directory are valid as well:
+
+`a.js`
+```javascript
+require('dir/b');
+
+var variableFromA = 'a';
 ```
+
+`dir/b.js`
+```javascript
+require('./c');
+
+var variableFromB = 'b';
+```
+
+`dir/c.js`
+```javascript
+var variableFromC = 'c';
+```
+
+Outputs
+
+```javascript
+(function(){
+  var variableFromC = 'c';
+})();
+
+(function(){
+
+  var variableFromB = 'b';
+})();
+
+(function(){
+
+  var variableFromA = 'a';
+})();
+```
+
+Note that directory traversal using `../` is **not** supported.
+
+## Example Gruntfile Use
+```javascript
 grunt.initConfig({
   neuter: {
     application: {
@@ -89,13 +131,11 @@ grunt.initConfig({
     }
   }
 });
-
 ```
 
 or
 
-
-```
+```javascript
 grunt.initConfig({
   neuter: {
       'tmp/application.js' :'app/index.js'
@@ -116,12 +156,19 @@ The wrapper around your code. Defaults to a closure-style function so locally de
 won't leak into the global scope. The text of your source JavaScript file is available as `src`
 within a template.
 
+### basePath
+Type: `String`
+
+Default: `""`
+
+Specifying a base path allows you to omit said portion of the filepath from your require statements. For example: when using `basePath: "lib/js/"` in your task options, `require("lib/js/file.js");` can instead be written as `require("file.js");`. Note that the trailing slash *must* be included.
+
 ### filepathTransform
 Type: `Function`
 
 Default: `function(filepath){ return filepath; }`
 
-Specifying a filepath transform allows you to omit said portion of the filepath from your require statements. For example: when using `filepathTransform: function(filepath){ return 'lib/js/' + filepath; }` in your task options, require("lib/js/file.js") can instead be written as require("file.js").
+Specifying a filepath transform allows you to control the path to the file that actually gets concatenated. For example, when using `filepathTransform: function(filepath){ return 'lib/js/' + filepath; }` in your task options, `require("lib/js/file.js");` can instead be written as `require("file.js");` (This achieves the same result as specifying `basePath: "lib/js/"`). When used in conjunction with the `basePath` option, the base path will be prepended to the `filepath` argument and a second argument will be provided that is the directory of the file **without** the `basePath`.
 
 ### includeSourceURL
 Type: `Boolean`

--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
     grunt.template.addDelimiters('neuter', '{%', '%}');
 
     var options = this.options({
+      basePath: '',
       filepathTransform: function(filepath){ return filepath; },
       template: "(function() {\n\n{%= src %}\n\n})();",
       separator: "\n\n",
@@ -66,6 +67,13 @@ module.exports = function(grunt) {
         return '';
       }
       files.forEach(function(filepath) {
+        // save the file's directory without the 'basePath' prefix
+        var dirname = (path.dirname(filepath) + '/').replace(options.basePath, '');
+
+        // create an absolute path to the file and prepend the 'basePath'
+        var normalizePath = function(path) {
+          return options.basePath + path.replace(/^\.\//, dirname) + '.js';
+        };
 
         // once a file has been required its source will
         // never be written to the resulting destination file again.
@@ -102,7 +110,7 @@ module.exports = function(grunt) {
               // apply the filepathTransform for matched files.
               var match = requireMatcher.exec(section);
               if (match) {
-                finder(options.filepathTransform(match[1]) + '.js');
+                finder(options.filepathTransform(normalizePath(match[1]), dirname));
               } else {
                 out.push({filepath: filepath, src: section});
               }

--- a/test/expected/relative_require_statements
+++ b/test/expected/relative_require_statements
@@ -1,0 +1,33 @@
+(function() {
+
+var a = 5;
+
+})();
+
+(function() {
+
+var simple_requires_come_before_here;
+
+
+})();
+
+(function() {
+
+var b = 'b, from within relative';
+
+
+})();
+
+(function() {
+
+var b_comes_before_here = 'a, from within relative';
+
+
+})();
+
+(function() {
+
+var relative_a_comes_before_here;
+
+
+})();

--- a/test/expected/relative_requires_with_basepath
+++ b/test/expected/relative_requires_with_basepath
@@ -1,0 +1,40 @@
+(function() {
+
+var a = 5;
+
+})();
+
+(function() {
+
+var simple_requires_come_before_here;
+
+
+})();
+
+(function() {
+
+var b = 'b, from within relative';
+
+
+})();
+
+(function() {
+
+var b_comes_before_here = 'a, from within relative';
+
+
+})();
+
+(function() {
+
+var a_comes_before_here = 'c, from within relative';
+
+
+})();
+
+(function() {
+
+var relative_c_comes_before_here;
+
+
+})();

--- a/test/fixtures/relative/a.js
+++ b/test/fixtures/relative/a.js
@@ -1,0 +1,3 @@
+require('./b');
+
+var b_comes_before_here = 'a, from within relative';

--- a/test/fixtures/relative/b.js
+++ b/test/fixtures/relative/b.js
@@ -1,0 +1,1 @@
+var b = 'b, from within relative';

--- a/test/fixtures/relative/c.js
+++ b/test/fixtures/relative/c.js
@@ -1,0 +1,3 @@
+require('relative/a');
+
+var a_comes_before_here = 'c, from within relative';

--- a/test/fixtures/relative_require_statements.js
+++ b/test/fixtures/relative_require_statements.js
@@ -1,0 +1,5 @@
+require('./simple_require');
+var simple_requires_come_before_here;
+
+require('./relative/a');
+var relative_a_comes_before_here;

--- a/test/fixtures/relative_requires_with_basepath.js
+++ b/test/fixtures/relative_requires_with_basepath.js
@@ -1,0 +1,5 @@
+require('./simple_require');
+var simple_requires_come_before_here;
+
+require('relative/c');
+var relative_c_comes_before_here;

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -19,6 +19,30 @@ exports.neuterTests = {
 
     test.done();
   },
+  simple_basepath_options: function(test) {
+
+    var actual = grunt.file.read('tmp/simple_basepath_options');
+    var expected = grunt.file.read('test/expected/simple_require_filepath_transforms');
+    test.equal(actual, expected, 'files are correctly combined');
+
+    test.done();
+  },
+  relative_require_statements: function(test) {
+
+    var actual = grunt.file.read('tmp/relative_require_statements');
+    var expected = grunt.file.read('test/expected/relative_require_statements');
+    test.equal(actual, expected, 'files are correctly combined');
+
+    test.done();
+  },
+  relative_requires_with_basepath: function(test) {
+
+    var actual = grunt.file.read('tmp/relative_requires_with_basepath');
+    var expected = grunt.file.read('test/expected/relative_requires_with_basepath');
+    test.equal(actual, expected, 'files are correctly combined');
+
+    test.done();
+  },
   custom_separator_options: function(test){
 
     var actual = grunt.file.read('tmp/custom_separator_options');


### PR DESCRIPTION
This PR is primarily to support relative paths using a dot. In order to support them however, neuter needs to know the 'base' path of the file (what is usually added by the filepath transform) so that it can omit it from the dot's replacement value. The simplest and most dev-friendly way to accomplish this is to just add an option that does the typical work of the `filepathTransform` automatically.

Note that this PR doesn't support relative paths without a `./` at the beginning as suggested in #23.
