### PR TITLE
Add 'process' option for preprocessing source files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,6 +141,29 @@ module.exports = function(grunt) {
         options: {
           includeSourceMap: true
         }
+      },
+      process_as_template: {
+        files: {
+          'tmp/process_as_template': ['test/fixtures/process_as_template.js']
+        },
+        options: {
+          process: {
+            data: {
+              foo: 5,
+              bar: 'baz'
+            }
+          }
+        }
+      },
+      process_with_function: {
+        files: {
+          'tmp/process_with_function': ['test/fixtures/simple_require.js']
+        },
+        options: {
+          process: function(src, filepath) {
+            return '// Source for: ' + filepath + '\n' + src;
+          }
+        }
       }
     },
     jshint: {

--- a/README.md
+++ b/README.md
@@ -144,3 +144,17 @@ Default: `[]`
 A list of files being required that should not be checked for further require statements.
 Useful for libraries that support other module building methods and leave their requires
 around in a way that isn't meaningful to neutering.
+
+### process
+Type: `Boolean` `Object` `Function` Default: `false`
+
+Process source files before concatenating, either as [templates](https://github.com/gruntjs/grunt/wiki/grunt.template) or with a custom function (similar to [grunt-contrib-concat](https://github.com/gruntjs/grunt-contrib-concat)). When using grunt for templating, the delimiters default to neuter's own special type (`{% %}`), which helps avoid errors when requiring libraries like [Underscore](http://underscorejs.org/) or [Lo-Dash](http://lodash.com/).
+
+* `false` - No processing will occur.
+* `true` - Process source files using [grunt.template.process][] without any data.
+* `options` object - Process source files using [grunt.template.process][], using the specified options.
+* `function(src, filepath)` - Process source files using the given function, called once for each file. The returned value will be used as source code.
+
+_(Default processing options are explained in the [grunt.template.process][] documentation)_
+
+  [grunt.template.process]: https://github.com/gruntjs/grunt/wiki/grunt.template#grunttemplateprocess

--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -38,8 +38,20 @@ module.exports = function(grunt) {
       template: "(function() {\n\n{%= src %}\n\n})();",
       separator: "\n\n",
       includeSourceMap: false,
-      skipFiles: []
+      skipFiles: [],
+      process: false
     });
+
+    // process, but with no data
+    if (options.process === true) {
+      options.process = {};
+    }
+
+    // default to using 'neuter' style templates for processing
+    // (this avoids issues with requiring underscore or lodash)
+    if (grunt.util.kindOf(options.process) === 'object') {
+      options.process.delimiters = options.process.delimiters || 'neuter';
+    }
 
     // a poor man's Set
     var skipFiles = {};
@@ -61,6 +73,13 @@ module.exports = function(grunt) {
           required.push(filepath);
 
           var src = grunt.file.read(filepath);
+
+          // process file as a template if specified
+          if (typeof options.process === 'function') {
+            src = options.process(src, filepath);
+          } else if (options.process) {
+            src = grunt.template.process(src, options.process);
+          }
 
           // if a file should not be nuetered
           // it is part of the skipFiles option

--- a/test/expected/process_as_template
+++ b/test/expected/process_as_template
@@ -1,0 +1,7 @@
+(function() {
+
+var foo = 5;
+
+
+
+})();

--- a/test/expected/process_with_function
+++ b/test/expected/process_with_function
@@ -1,0 +1,6 @@
+(function() {
+
+// Source for: test/fixtures/simple_require.js
+var a = 5;
+
+})();

--- a/test/fixtures/process_as_template.js
+++ b/test/fixtures/process_as_template.js
@@ -1,0 +1,4 @@
+var foo = {%= foo %};
+{% if (bar !== 'baz') { %}
+require('a');
+{% } %}

--- a/test/neuter_test.js
+++ b/test/neuter_test.js
@@ -126,5 +126,21 @@ exports.neuterTests = {
     test.equal(actualMap, expectedMap, 'the map is generated');
 
     test.done();
+  },
+
+  process_as_template: function(test) {
+    var actual = grunt.file.read('tmp/process_as_template');
+    var expected = grunt.file.read('test/expected/process_as_template');
+    test.equal(actual, expected, 'files are processed as templates');
+
+    test.done();
+  },
+
+  process_with_function: function(test) {
+    var actual = grunt.file.read('tmp/process_with_function');
+    var expected = grunt.file.read('test/expected/process_with_function');
+    test.equal(actual, expected, 'files are processed with a function');
+
+    test.done();
   }
 };


### PR DESCRIPTION
This adds support for preprocessing templates before neuter get's a chance to do its thing. It's modeled after the option of the same name in [grunt-contrib-concat](https://github.com/gruntjs/grunt-contrib-concat#process).

Preprocessing templates enables conditional requires based on the environment, e.g.

``` javascript
// {% if (env.DEBUG) { %}
require('debug-version');
// {% } else { %}
require('release-version');
// {% } %}
```
