### PR TITLE
Fixed issue with finder() not confirming the length of glob result

### DIFF
--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -62,7 +62,7 @@ module.exports = function(grunt) {
 
     var finder = function(globPath){
       var files = glob.sync(globPath, {});
-      if (!files) {
+      if (!files || !files.length) {
         grunt.log.error('No files found at "' + globPath + '".');
         return '';
       }


### PR DESCRIPTION
When `finder()` globs the required path, it only checks that the result is falsy, not if the array is empty. When someone `require('some-non-existent-file')` it silently fails to include anything because an empty array is returned.
