### PR TITLE
Fail when required file is missing. Fixes #45

### DIFF
--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -63,7 +63,23 @@ module.exports = function(grunt) {
     var finder = function(globPath){
       var files = glob.sync(globPath, {});
       if (!files || !files.length) {
-        grunt.log.error('No files found at "' + globPath + '".');
+        if(globPath.match(/[\*\?\[{]/)) {
+            // see Issue #45
+            // https://github.com/trek/grunt-neuter/issues/45
+            //
+            // glob didn't find files matching a wildcard. That's ok, just warn
+            // that nothing is there; user might have misspelled the directory
+            // name or put the files on the wrong place. Either way, wildcard
+            // means "zero or more", so warn, but continue.
+            grunt.log.warn('No files found at "' + globPath + '".');
+        }
+        else {
+          // Not a wildcard, so this should have resolved to an actual file.
+          // require() on a specific file name means that the specified file is
+          // , well, required for the build.
+          // Since that's missing now, bail and fail.
+          grunt.fail.warn('File not found: ' + globPath);
+        }
         return '';
       }
       files.forEach(function(filepath) {


### PR DESCRIPTION
I've had the situation where I accidently `require()`d a missing file. The app built fine, but then didn't run.

It took me a while to figure out why my app wasn't working until I found out that neuter silently ignored the missing file, concatenated the remaining ones and continued with the build. (I was using an older version of neuter that didn't warn about missing files as it was only checking for `!files` and not `!files.length`, but I see that's changed now). At runtime, of course, everything from the missing file was missing in the code and caused errors.

I think the expected behaviour is the following:
- `require()` means that something is _required_ for a build
- wildcard names can resolve to zero or more files. So zero is ok, but probably worth knowing about.
- requiring a specific file means that file is required. If it's missing, there is something seriously wrong.

I fixed this the following way:

If `glob` returns zero files and `require()` was called with...
- ... a wildcard character: issue a warning and continue with the build (`grunt.log.warn`)
- ... with a specific file name (no wildcards): issue a warning and fail (`grunt.fail.warn`).

Thanks :)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/trek/grunt-neuter/46)

<!-- Reviewable:end -->
