### PR TITLE
Fixed multi dest files source generating

### DIFF
--- a/tasks/neuter.js
+++ b/tasks/neuter.js
@@ -141,6 +141,8 @@ module.exports = function(grunt) {
 				};
 			});
 
+        required = [];
+
       // test if template block has newlines to offset against
       var m, n, beforeOffset, afterOffset;
       if (m = options.template.match(/([\S\s]*)(?={%= src %})/)) {
@@ -196,6 +198,7 @@ module.exports = function(grunt) {
 				newSourceMap.file = path.basename(newSourceMap.file);
 				grunt.file.write(file.dest + ".map", JSON.stringify(newSourceMap, null, '  '));
 			}
+        out = [];
     });
   });
 };


### PR DESCRIPTION
When there is more then one output (destination) file, it duplicate source for every file. For example if we have four file then fourth will have source from first, second third and fourth. 

After file output I've set empty array for `out` and `requested` variables.  
